### PR TITLE
Saving image names, pan/zoom, bug-fixes and expanded README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ points per frame. Please consider contributing for multiple instances per frame!
 # Installation
 * pip install pose-annotator
 
+# Usage
+Customize [default_config.yaml](pose_annotator/gui/default_config.yaml) then launch using
+ `pose_annotator usr_cfg=path/to/custom/config.yaml` 
+
 # Known issues
+* Adding or deleting images from a directory with existing annotations
+	* annotations are matched to image files by rank-order of the filename
 * `ModuleNotFoundError: No module named 'skbuild'`
   * please `pip install --upgrade pip`
-  

--- a/README.md
+++ b/README.md
@@ -2,14 +2,25 @@
 A simple GUI for clicking on keypoints for training pose estimation models. Currently only supports one set of 
 points per frame. Please consider contributing for multiple instances per frame!
 
-# Installation
+## Installation
 * pip install pose-annotator
 
-# Usage
+## Usage
 Customize [default_config.yaml](pose_annotator/gui/default_config.yaml) then launch using
  `pose_annotator usr_cfg=path/to/custom/config.yaml` 
+ 
+#### Hotkeys 
+* `Ctrl+S` save
+* `Right` next frame
+* `Left` previous frame
+* `Down` next keypoint
+* `Space` next keypoint
+* `Up` previous keypoint
+* `Delete` delete keypoint
 
-# Known issues
+ 
+
+## Known issues
 * Adding or deleting images from a directory with existing annotations
 	* annotations are matched to image files by rank-order of the filename
 * `ModuleNotFoundError: No module named 'skbuild'`

--- a/pose_annotator/gui/custom_widgets.py
+++ b/pose_annotator/gui/custom_widgets.py
@@ -46,8 +46,6 @@ class ClickableScene(QtWidgets.QGraphicsScene):
     release = QtCore.Signal(QtGui.QMouseEvent)
     def __init__(self, parent=None):
         super().__init__(parent)
-
-
         
     def mousePressEvent(self, event):
         if event.buttons():
@@ -439,7 +437,7 @@ class KeypointGroup(QtWidgets.QWidget):
     data = Signal(dict)
     
     def __init__(self, keypoint_dict, scene, parent=None, colormap:str='viridis', radius=20, 
-                 text_over_mouse=True):
+                 text_over_mouse=True, click_type_to_add_keypoint='right'):
         super().__init__(parent)
         
         self.cmap = plt.get_cmap(colormap)
@@ -462,6 +460,7 @@ class KeypointGroup(QtWidgets.QWidget):
         self.scene = scene
         self.tmp_selected = None
         self.text_over_mouse = text_over_mouse
+        self.click_type_to_add_keypoint = click_type_to_add_keypoint
         self.set_data(keypoint_dict)
         self.text = None
         self.update_text()
@@ -545,7 +544,7 @@ class KeypointGroup(QtWidgets.QWidget):
         self.text.setBrush(brush)
         self.text.setPen(pen)
     
-    def right_click(self, event):
+    def add_keypoint(self, event):
         pos = event.scenePos()
         x, y = pos.x(), pos.y()
         
@@ -557,7 +556,7 @@ class KeypointGroup(QtWidgets.QWidget):
         # print(x,y)
         self.set_selected(self.index+1)
         
-    def left_click(self, event):
+    def move_keypoint(self, event):
         pos = event.scenePos()
         x, y = pos.x(), pos.y()
         dists = self.get_distance_to_keypoints(x, y)
@@ -593,9 +592,16 @@ class KeypointGroup(QtWidgets.QWidget):
     @Slot(QtGui.QMouseEvent)
     def receive_click(self, event):
         if event.button() == QtCore.Qt.RightButton:
-            self.right_click(event)
+            if self.click_type_to_add_keypoint == 'left':
+                self.move_keypoint(event)
+            else:
+                self.add_keypoint(event)
+
         elif event.button() == QtCore.Qt.LeftButton:
-            self.left_click(event)
+            if self.click_type_to_add_keypoint == 'left':
+                self.add_keypoint(event)
+            else:
+                self.move_keypoint(event)
     
     @Slot(QtGui.QMouseEvent)
     def receive_move(self, event):

--- a/pose_annotator/gui/custom_widgets.py
+++ b/pose_annotator/gui/custom_widgets.py
@@ -95,6 +95,9 @@ class VideoFrame(QtWidgets.QGraphicsView):
         self.setMouseTracking(True)    
     
     def initialize_image(self, imagefile: Union[str, os.PathLike])    : 
+        if self.vid is not None:
+            self.vid.close()
+            
         self.videofile = imagefile
         assert os.path.isfile(imagefile)
         

--- a/pose_annotator/gui/custom_widgets.py
+++ b/pose_annotator/gui/custom_widgets.py
@@ -97,7 +97,8 @@ class VideoFrame(QtWidgets.QGraphicsView):
     def initialize_image(self, imagefile: Union[str, os.PathLike])    : 
         if self.vid is not None:
             self.vid.close()
-            
+            self.vid = None
+
         self.videofile = imagefile
         assert os.path.isfile(imagefile)
         
@@ -120,14 +121,23 @@ class VideoFrame(QtWidgets.QGraphicsView):
     def initialize_video(self, videofile: Union[str, os.PathLike]):
         if self.vid is not None:
             self.vid.close()
-            # if hasattr(self.vid, 'cap'):
-            #     self.vid.cap.release()
+            self.vid = None
+
         self.videofile = videofile
         self.vid = VideoReader(videofile)
         # self.frame = next(self.vid)
         self.initialized.emit(len(self.vid))
         # there was a bug where sometimes subsequent videos with the same frame would not update the image
         self.update_frame(0, force_update=True)
+
+    def get_image_names(self):
+        if self.vid is None: # single image
+            return [self.videofile]
+        elif isinstance(self.vid.file_object, list): # image directory 
+            return [os.path.split(n)[1] for n in self.vid.file_object]
+        else: # video
+            return [self.videofile]*len(self.vid)
+        
 
     def update_frame(self, value, force_update: bool=False):
         # print('updating')

--- a/pose_annotator/gui/custom_widgets.py
+++ b/pose_annotator/gui/custom_widgets.py
@@ -609,12 +609,11 @@ class KeypointGroup(QtWidgets.QWidget):
         x, y = pos.x(), pos.y()
         # print(x,y)
         # print(event.buttons())
-        if event.buttons() == QtCore.Qt.LeftButton:
-            # print(self.tmp_selected)
+        if ((self.click_type_to_add_keypoint != 'left' and event.buttons() == QtCore.Qt.LeftButton) or
+            (self.click_type_to_add_keypoint == 'left' and event.buttons() == QtCore.Qt.RightButton)):
             if self.tmp_selected is None:
                 return
-            
-            
+
             self.keypoints[self.keys[self.tmp_selected]].set_coords(x, y, self.radius)
             self.broadcast_data()
         if self.text_over_mouse:

--- a/pose_annotator/gui/default_config.yaml
+++ b/pose_annotator/gui/default_config.yaml
@@ -11,4 +11,5 @@ autosave: False
 save_loc: null
 path: null
 user_cfg: null
+resize_on_each_frame: True
 

--- a/pose_annotator/gui/default_config.yaml
+++ b/pose_annotator/gui/default_config.yaml
@@ -7,6 +7,8 @@ viz:
   radius: 5
   text_over_mouse: True
 save_image_names: False
+autosave: False
 save_loc: null
 path: null
 user_cfg: null
+

--- a/pose_annotator/gui/default_config.yaml
+++ b/pose_annotator/gui/default_config.yaml
@@ -6,6 +6,7 @@ viz:
   colormap: viridis
   radius: 5
   text_over_mouse: True
+save_image_names: False
 save_loc: null
 path: null
 user_cfg: null

--- a/pose_annotator/gui/default_config.yaml
+++ b/pose_annotator/gui/default_config.yaml
@@ -12,4 +12,4 @@ save_loc: null
 path: null
 user_cfg: null
 resize_on_each_frame: True
-
+click_type_to_add_keypoint: right

--- a/pose_annotator/gui/main.py
+++ b/pose_annotator/gui/main.py
@@ -37,8 +37,9 @@ class MainWindow(QtWidgets.QMainWindow):
         # self.keypoint_dict = {key: [] for key in keys}
         self.keypoints = None
         
-        self.keypoints = KeypointGroup(self.keypoint_dict, self.player.videoView.scene, 
-                                       parent=self.player, colormap=self.cfg.viz.colormap, radius=self.cfg.viz.radius)
+        self.keypoints = KeypointGroup(self.keypoint_dict, self.player.videoView.scene, parent=self.player, 
+                                       colormap=self.cfg.viz.colormap, radius=self.cfg.viz.radius,
+                                       click_type_to_add_keypoint=self.cfg.click_type_to_add_keypoint)
         
         self.keypoint_selector = KeypointButtons(keys, colormap=cfg.viz.colormap, parent=self)
         self.ui.verticalLayout_2.addWidget(self.keypoint_selector)

--- a/pose_annotator/gui/main.py
+++ b/pose_annotator/gui/main.py
@@ -61,7 +61,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.keypoint_selector.selected.connect(self.keypoints.set_selected)
         self.keypoints.selected.connect(self.keypoint_selector.set_selected)
         self.player.videoView.frameNum.connect(self.update_framenum)
-        
+
         # menu buttons
         self.ui.actionOpen_image.triggered.connect(self.open_image_file)
         self.ui.actionOpen_image_directory.triggered.connect(self.open_image_directory)
@@ -105,6 +105,9 @@ class MainWindow(QtWidgets.QMainWindow):
                 raise ValueError('filetype of input not known: {}'.format(cfg.path))
             self.initialize_new_file(cfg.path, filetype)
         
+
+        self.initialize_new_file('/Users/calebsw/Dropbox (HMS)/caleb weinreb/PROJECTS/MOUSE_SURVEILANCE/21_2_19_segmentation_redux/C57_vs_C57_v2/training_data/annotations1_top','video')
+
         self.show()
         
     def get_save_loc(self):
@@ -223,31 +226,11 @@ class MainWindow(QtWidgets.QMainWindow):
     
     
     def save(self):
-        # has_any_data = []
-        # for element in self.data:
-        #     frame_has_data = False
-        #     for key, value in element.items():
-        #         if len(value) > 0:
-        #             frame_has_data = True
-        #             break
-        #     has_any_data.append(frame_has_data)
-        
-        # data = {}
-        # for i, element in enumerate(self.data):
-        #     row = {}
-        #     if not has_any_data[i]:
-        #         continue
-        #     for key, value in element.items():
-        #         if value is None:
-        #             value = [np.nan, np.nan, 0]
-        #         row[key + '_x'] = value[0]
-        #         row[key + '_y'] = value[1]
-        #         row[key + '_p'] = 1
-        #     data[i] = row
-            
-        # df = pd.DataFrame(data)
-        # # switch rows and columns
-        # df = df.T
+        # add image names to data
+        if self.cfg.save_image_names:
+            image_names = self.player.videoView.get_image_names()
+            for row,name in zip(self.data,image_names): row['image_name'] = name
+
         df = utils.convert_data_to_df(self.data)
         df.to_csv(self.save_filename)
         print('saving to {}'.format(self.save_filename))
@@ -258,6 +241,8 @@ class MainWindow(QtWidgets.QMainWindow):
         assert os.path.isfile(filename)
         print('loading from {}'.format(filename))
         df = pd.read_csv(filename, index_col=0)
+        if 'image_name' in df: del df['image_name']
+
         # data is initialized when we load our video
         data = utils.convert_df_to_data(df, len(self.data), self.keypoint_dict)
         df.head()

--- a/pose_annotator/gui/main.py
+++ b/pose_annotator/gui/main.py
@@ -4,6 +4,8 @@ from functools import partial
 import os
 import sys
 
+os.environ['QT_MAC_WANTS_LAYER'] = '1'
+
 import numpy as np
 from omegaconf import OmegaConf, DictConfig
 import pandas as pd

--- a/pose_annotator/gui/main.py
+++ b/pose_annotator/gui/main.py
@@ -202,9 +202,8 @@ class MainWindow(QtWidgets.QMainWindow):
         # keep the real data
         self.data[self.framenum] = deepcopy(data)
         self.saved = False
-        # print(self.data)
-        # print(data)
-        # print(self.keypoint_dict)
+        if self.cfg.autosave:
+            self.save()
             
     @QtCore.Slot(int)
     def update_framenum(self, framenum, force: bool=False):
@@ -227,11 +226,11 @@ class MainWindow(QtWidgets.QMainWindow):
     
     def save(self):
         # add image names to data
+        image_names = None
         if self.cfg.save_image_names:
             image_names = self.player.videoView.get_image_names()
-            for row,name in zip(self.data,image_names): row['image_name'] = name
 
-        df = utils.convert_data_to_df(self.data)
+        df = utils.convert_data_to_df(self.data, image_names=image_names)
         df.to_csv(self.save_filename)
         print('saving to {}'.format(self.save_filename))
         self.saved = True

--- a/pose_annotator/gui/main.py
+++ b/pose_annotator/gui/main.py
@@ -28,11 +28,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle('Pose Annotator')
         
         self.player = self.ui.widget
+        self.player.videoView.resize_on_each_frame = self.cfg.resize_on_each_frame
         # for convenience
         self.scene = self.player.scene
-        # self.player.videoView.initialize_image('/media/jim/DATA_SSD/armo/dataset_for_labeling/images/SS21_190508_140054_002526/SS21_190508_140054_002526_right_post_l.png')
-        # self.player.videoView.initialize_video('/media/jim/DATA_SSD/armo/dataset_for_labeling/images/SS21_190508_140054_002526')
-        
+         
         keys = OmegaConf.to_container(cfg.keypoints)
         self.keypoint_dict = OrderedDict({key: [] for key in keys})
         # self.keypoint_dict = {key: [] for key in keys}
@@ -105,9 +104,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 raise ValueError('filetype of input not known: {}'.format(cfg.path))
             self.initialize_new_file(cfg.path, filetype)
         
-
-        self.initialize_new_file('/Users/calebsw/Dropbox (HMS)/caleb weinreb/PROJECTS/MOUSE_SURVEILANCE/21_2_19_segmentation_redux/C57_vs_C57_v2/training_data/annotations1_top','video')
-
         self.show()
         
     def get_save_loc(self):

--- a/pose_annotator/gui/main.py
+++ b/pose_annotator/gui/main.py
@@ -61,11 +61,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self.keypoint_selector.selected.connect(self.keypoints.set_selected)
         self.keypoints.selected.connect(self.keypoint_selector.set_selected)
         self.player.videoView.frameNum.connect(self.update_framenum)
+        
         # menu buttons
         self.ui.actionOpen_image.triggered.connect(self.open_image_file)
         self.ui.actionOpen_image_directory.triggered.connect(self.open_image_directory)
         self.ui.actionOpen_video.triggered.connect(self.open_video)
-        
+        self.ui.actionSave.triggered.connect(self.save)
+
         # hotkeys
         save_shortcut = QtWidgets.QShortcut(QtGui.QKeySequence('Ctrl+S'), self)
         save_shortcut.activated.connect(self.save)

--- a/pose_annotator/utils.py
+++ b/pose_annotator/utils.py
@@ -42,12 +42,11 @@ def convert_data_to_df(data: list, image_names=None) -> pd.DataFrame:
         indices.append(i)
 
     df = pd.DataFrame( data=rows, columns=keys, index=indices)
-
     if image_names is not None:
         df = df.join(pd.DataFrame(
             data=[image_names[i] for i in indices], 
             columns=['image_name'], index=indices))
-        
+
     return df
 
 def convert_row_to_dict(row) -> dict:

--- a/pose_annotator/utils.py
+++ b/pose_annotator/utils.py
@@ -14,7 +14,7 @@ def check_for_any_data(data: list) -> list:
         has_any_data.append(frame_has_data)
     return has_any_data
 
-def convert_data_to_df(data: list) -> pd.DataFrame:
+def convert_data_to_df(data: list, image_names=None) -> pd.DataFrame:
     has_any_data = check_for_any_data(data)
     
     # rows = {}
@@ -26,29 +26,28 @@ def convert_data_to_df(data: list) -> pd.DataFrame:
         if not has_any_data[i]:
             continue
         for key, value in element.items():
-            if key=='image_name':
-                row[key] = value
-                if i==0:
-                    keys.append(key)
+            if value is None or np.isnan(value).sum() > 0:
+                value = [np.nan, np.nan]
+                p = 0
             else:
-                if value is None or np.isnan(value).sum() > 0:
-                    value = [np.nan, np.nan]
-                    p = 0
-                else:
-                    p = 1
-                row[key + '_x'] = value[0]
-                row[key + '_y'] = value[1]
-                row[key + '_p'] = p
-                if i == 0:
-                    keys.append(key + '_x')
-                    keys.append(key + '_y')
-                    keys.append(key + '_p')
+                p = 1
+            row[key + '_x'] = value[0]
+            row[key + '_y'] = value[1]
+            row[key + '_p'] = p
+            if i == 0:
+                keys.append(key + '_x')
+                keys.append(key + '_y')
+                keys.append(key + '_p')
         rows.append(row)
         indices.append(i)
-    df = pd.DataFrame( data=rows, columns=keys, index=indices)
-    # switch rows and columns
-    # df = df.T
 
+    df = pd.DataFrame( data=rows, columns=keys, index=indices)
+
+    if image_names is not None:
+        df = df.join(pd.DataFrame(
+            data=[image_names[i] for i in indices], 
+            columns=['image_name'], index=indices))
+        
     return df
 
 def convert_row_to_dict(row) -> dict:

--- a/pose_annotator/utils.py
+++ b/pose_annotator/utils.py
@@ -8,7 +8,7 @@ def check_for_any_data(data: list) -> list:
     for element in data:
         frame_has_data = False
         for key, value in element.items():
-            if len(value) > 0:
+            if key != 'image_name' and len(value) > 0:
                 frame_has_data = True
                 break
         has_any_data.append(frame_has_data)
@@ -26,18 +26,23 @@ def convert_data_to_df(data: list) -> pd.DataFrame:
         if not has_any_data[i]:
             continue
         for key, value in element.items():
-            if value is None or np.isnan(value).sum() > 0:
-                value = [np.nan, np.nan]
-                p = 0
+            if key=='image_name':
+                row[key] = value
+                if i==0:
+                    keys.append(key)
             else:
-                p = 1
-            row[key + '_x'] = value[0]
-            row[key + '_y'] = value[1]
-            row[key + '_p'] = p
-            if i == 0:
-                keys.append(key + '_x')
-                keys.append(key + '_y')
-                keys.append(key + '_p')
+                if value is None or np.isnan(value).sum() > 0:
+                    value = [np.nan, np.nan]
+                    p = 0
+                else:
+                    p = 1
+                row[key + '_x'] = value[0]
+                row[key + '_y'] = value[1]
+                row[key + '_p'] = p
+                if i == 0:
+                    keys.append(key + '_x')
+                    keys.append(key + '_y')
+                    keys.append(key + '_p')
         rows.append(row)
         indices.append(i)
     df = pd.DataFrame( data=rows, columns=keys, index=indices)


### PR DESCRIPTION
- Added option for left-click to add keypoint (disabled in default config)
- Added option pan/zoom with macbook track pad (disabled in default config)
- Added option to save image names (disabled in default config)
- Put hotkeys in README
- Put more usage info in README
- Fixed bug: Video was not being cleared from memory user loaded an image after loading a video
- Fixed bug: Save menu button was not connected to anything

